### PR TITLE
Added the HyperlinkedDebugTree

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -271,6 +271,17 @@ class Timber private constructor() {
     }
   }
 
+  /**
+   * A [Tree] for debug builds.
+   * Automatically shows a Hyperlink to the calling Class and Linenumber in the Logs.
+   * Allows quick lookup of the caller source just by clicking on the Hyperlink in the Log.
+   * @param showMethodName Whether or not to show the method name as well
+   */
+  class HyperlinkedDebugTree(private val showMethodName: Boolean = true) : DebugTree() {
+    override fun createStackElementTag(element: StackTraceElement) =
+            with(element) { "($fileName:$lineNumber) ${if (showMethodName) " $methodName()" else ""}" }
+  }
+
   companion object Forest : Tree() {
     /** Log a verbose message with optional format args. */
     @JvmStatic override fun v(@NonNls message: String?, vararg args: Any?) {


### PR DESCRIPTION
It creates logs that include hyperlinks to the calling line and class.
This way you can just click on the Tag and directly jump to the source. Very useful in big projects.